### PR TITLE
Added prefix for the blank nodes internal query

### DIFF
--- a/src/ontodia/data/sparql/sparqlDataProvider.ts
+++ b/src/ontodia/data/sparql/sparqlDataProvider.ts
@@ -345,7 +345,7 @@ export class SparqlDataProvider implements DataProvider {
             .then(result => {
                 if (this.options.acceptBlankNodes) {
                     return BlankNodes.updateFilterResults(result, blankQuery =>
-                        this.executeSparqlQuery<BlankBinding>(blankQuery));
+                        this.executeSparqlQuery<BlankBinding>(blankQuery), this.settings);
                 }
                 return result;
             }).then(getFilteredData);


### PR DESCRIPTION
There were internal query in blank nodes support without any prefixes, some SPARQL endpoints fired errors for not defining `rdf:` prefix.

BTW the code is so deeply nested and if we continue to use blank nodes functionality a lot, we should refactor this code.