### PR TITLE
Add build to npm prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint": "./node_modules/.bin/tslint -c tslint.ci.json --project tsconfig.json --exclude '**/*.d.ts' -t stylish",
     "_typings-tsc": "./node_modules/.bin/tsc --declaration --emitDeclarationOnly --outDir dist/temp/dts",
     "_typings-dts-bundle": "./node_modules/.bin/dts-bundle --main dist/temp/dts/index.d.ts --name ontodia --out ../../ontodia.d.ts",
-    "_webpack": "./node_modules/.bin/webpack"
+    "_webpack": "./node_modules/.bin/webpack",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "d3-color": "~1.0.2",


### PR DESCRIPTION
This will create the dist files when a user adds this library as git repository to her project. Like this any project can add the ontodia git repository as a dependency, instead of the version that is published on npm.